### PR TITLE
use user cache dir

### DIFF
--- a/mumble/mumble.py
+++ b/mumble/mumble.py
@@ -13,6 +13,7 @@ import warnings
 
 import pandas as pd
 import pickle
+import platformdirs
 from psm_utils.io import read_file, write_file
 from psm_utils import PSMList, PSM, Peptidoform
 from psm_utils.utils import mz_to_mass
@@ -828,7 +829,9 @@ class _ModificationCache:
         return:
             str: path to cache file
         """
-        return str(importlib.resources.files("mumble.package_data") / "modifications_cache.pkl")
+        cache_dir = platformdirs.user_cache_dir(appname="mumble")
+        os.makedirs(cache_dir, exist_ok=True)
+        return os.path.join(cache_dir, "modifications_cache.pkl")
 
     @staticmethod
     def _calculate_file_hash(file_path: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "pandas >= 1.5.0",
     "psm_utils >= 0.9.0",
     "numpy >= 1.23.0",
-    "rustyms >= 0.8.0"
+    "rustyms >= 0.8.0",
+    "platformdirs >= 3.0.0",
 ]
 requires-python = ">=3.10"
 


### PR DESCRIPTION
Currently the modification cache is stored based on the installation location. This is not ideal, and problematic in e.g. a docker image. This uses the the correct user cache dir, based on the platform of the user.