### PR TITLE
updated small package bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ output_files/
 # vscode
 .vscode
 .vscode/*
+
+# uv 
+uv.lock

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The PSM Modification Handler is a Python-based tool designed to find candidate u
 
 ### Prerequisites
 
-- Python 3.9 or higher
+- Python 3.10 or higher
 - pip (Python package installer)
 
 ### Required Libraries
@@ -55,7 +55,7 @@ Here are the available options you can pass when running the command:
 - **`--fasta-file`**: Path to a fasta file (for use with `aa_combinations`).
 - **`--mass-error`**: Mass error for the mass shift, default is `0.02`.
 - **`--output-file`**: Path to the output file to write modified PSMs.
-- **`--filetype-write`**: Type of the output file to write with PSM_utils (e.g., `tsv`, `csv`). Default is `tsv`.
+- **`--write-filetype`**: Type of the output file to write with PSM_utils (e.g., `tsv`, `csv`). Default is `tsv`.
 - **`--include-decoy-psm`**: Flag to parse modifications for decoys in the modified PSM list.
 - **`--include-original-psm`**: Flag to keep the original PSMs in the modified PSM list.
 - **`--combination-length`**: Maximum number of modifications per combination. All lower numbers will be included as well. Default is `1`.
@@ -74,7 +74,7 @@ mumble --psm-list "path/to/psm_file.mzid" --mass-error 0.02 --output-file "modif
 
 2. **Modify a list of PSMs with custom configurations**:
 ```bash
-mumble --psm-list "path/to/psm_file.mzid" --fasta-file "path/to/proteins.fasta" --aa-combinations 5 --config-file "path/to/config_file.toml"
+mumble --psm-list "path/to/psm_file.mzid" --fasta-file "path/to/proteins.fasta" --aa-combinations 5 --config-file "path/to/config_file.json"
 ```
 
 3. **Clear the cache and exit**:
@@ -94,17 +94,18 @@ You can also use a configuration file to specify options that will be loaded aut
 Example configuration file (`config_file.json`):
 
 ```json
-{"mass_error" : 0.05
-"aa_combinations" : 2
-"psm_file_type" : "mzid"
-"output_file" : "output.tsv"
+{
+    "mass_error": 0.05,
+    "aa_combinations": 2,
+    "psm_file_type": "mzid",
+    "output_file": "output.tsv"
 }
 ```
 
 You can then specify the path to this file using the `--config-file` option:
 
 ```bash
-mumble --config-file "path/to/config_file.toml"
+mumble --config-file "path/to/config_file.json"
 ```
 
 ### Python API 
@@ -123,7 +124,7 @@ Here's a quick example of how to use the PSM Modification Handler through the py
 ...     precursor_mz=228.129628 # Required information
 ... )
 >>> # Generate proteoforms for given PSM with a certain MZ
->>> modified_proteoforms = PSMHandler.get_modified_peptidoforms_list(psm, keep_original=False)
+>>> modified_proteoforms = psm_handler.get_modified_peptidoforms_list(psm, include_original_psm=False)
 
 
 >>> # Write the modified PSM list to a file
@@ -139,11 +140,14 @@ Here's a quick example of how to use the PSM Modification Handler through the py
 ```
 Here's a quick example of how to use the PSM Modification Handler through the python API for PSM lists:
 ```python
->>> # Or load a PSM list (from a file or PSMList object)
->>> psm_list = psm_handler.parse_psm_list("path/to/psm_file.mzid", psm_file_type="mzid")
-
->>> # Add modified PSMs to the list
->>> modified_psm_list = psm_handler.add_modified_psms(psm_list, generate_modified_decoys=False, keep_original=True)
+>>> # Add modified PSMs, reading directly from a PSM file
+>>> # (add_modified_psms also accepts a list of PSM objects or a PSMList)
+>>> modified_psm_list = psm_handler.add_modified_psms(
+...     "path/to/psm_file.mzid",
+...     psm_file_type="mzid",
+...     include_decoy_psm=False,
+...     include_original_psm=True,
+... )
 
 >>> # Write the modified PSM list to a file
 >>> psm_handler.write_modified_psm_list(modified_psm_list, output_file="modified_psms.tsv", psm_file_type="tsv")
@@ -175,7 +179,7 @@ Contributions are welcome! Please follow these steps:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/mumble/__main__.py
+++ b/mumble/__main__.py
@@ -53,7 +53,7 @@ CLI_OPTIONS = {
         "help": "Path to the output file",
         "default": None,
     },
-    "filetype_write": {
+    "write_filetype": {
         "type": click.STRING,
         "help": "Type of the output file to write with PSM_utlis.io.write_file",
         "default": "tsv",

--- a/mumble/file_handler.py
+++ b/mumble/file_handler.py
@@ -233,7 +233,7 @@ class _MetadataParser:
             return []
 
         # Clean up any whitespace in DataFrame
-        df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
+        df = df.map(lambda x: x.strip() if isinstance(x, str) else x)
 
         # Create a list of PSM objects from the DataFrame rows
         peptidoforms = [

--- a/mumble/mumble.py
+++ b/mumble/mumble.py
@@ -277,16 +277,16 @@ class PSMHandler:
         Returns:
             psm_utils.PSMList: A new PSMList object containing the modified PSMs.
         """
-        if not psm_list:
+        if psm_list is None:
             if psm_list := self.params["psm_list"]:
                 pass
             else:
                 raise ValueError("No PSM list provided")
-        if not include_decoy_psm:
+        if include_decoy_psm is None:
             include_decoy_psm = self.params["include_decoy_psm"]
-        if not include_original_psm:
+        if include_original_psm is None:
             include_original_psm = self.params["include_original_psm"]
-        if not psm_file_type:
+        if psm_file_type is None:
             psm_file_type = self.params["psm_file_type"]
 
         logger.info(

--- a/mumble/mumble.py
+++ b/mumble/mumble.py
@@ -23,7 +23,6 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeEl
 from rich.pretty import pretty_repr
 from sqlalchemy import exc
 
-
 # Add a logger
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ mumble = "mumble.__main__:main"
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.ruff]
 line-length = 99
-target-version = 'py38'
+target-version = 'py310'
 
 [tool.ruff.lint]
 extend-select = ["T201", "T203"]

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -375,8 +375,9 @@ class TestMetadataParser:
         ABCD/2\tspec2\t300.2
         """
 
-        with patch("builtins.open", mock_open(read_data=csv_data)), patch(
-            "pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")
+        with (
+            patch("builtins.open", mock_open(read_data=csv_data)),
+            patch("pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")),
         ):
             peptidoforms = metadata_handler.parse_csv_file("dummy_file.tsv")
 
@@ -394,8 +395,9 @@ class TestMetadataParser:
         ABCD\tspec2
         """
 
-        with patch("builtins.open", mock_open(read_data=csv_data)), patch(
-            "pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")
+        with (
+            patch("builtins.open", mock_open(read_data=csv_data)),
+            patch("pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")),
         ):
             peptidoforms = metadata_handler.parse_csv_file("dummy_file.tsv", delimiter="\t")
 
@@ -415,8 +417,9 @@ class TestMetadataParser:
         # Mock empty CSV data
         csv_data = """peptidoform\tspectrum_id\tprecursor_mz"""
 
-        with patch("builtins.open", mock_open(read_data=csv_data)), patch(
-            "pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")
+        with (
+            patch("builtins.open", mock_open(read_data=csv_data)),
+            patch("pandas.read_csv", return_value=pd.read_csv(StringIO(csv_data), delimiter="\t")),
         ):
             peptidoforms = metadata_handler.parse_csv_file("dummy_file.tsv", delimiter="\t")
 


### PR DESCRIPTION
## Summary

Fixes a set of documentation/code drifts and small bugs found while reviewing the package, so Mumble can be used more reliably from both the CLI and the Python API.

## Bug fixes

- **CLI write-format option was a no-op.** The CLI option was keyed `filetype_write`, but `PSMHandler` reads `write_filetype`, so the value never propagated. Renamed the option; the flag is now `--write-filetype` and correctly sets the output format.
- **`add_modified_psms` ignored an explicit `False`.** The "argument omitted" checks used `if not <arg>:` for `include_decoy_psm`, `include_original_psm`, and `psm_file_type`, which also triggered when a caller passed `False`, silently overriding it with the config default. Changed to `is None` checks.
- **`DataFrame.applymap` removed in pandas 2.1+.** Replaced with `DataFrame.map` in `file_handler.py`, fixing two failing tests.

## Consistency / docs

- README license corrected from MIT to Apache 2.0 (matches `LICENSE` and `pyproject.toml`).
- README minimum Python raised from 3.9 to 3.10 (matches `requires-python`).
- `black`/`ruff` `target-version` bumped from `py38` to `py310`.
- README Python API examples updated to real signatures: instance method `get_modified_peptidoforms_list(psm, include_original_psm=...)`, and `add_modified_psms(..., include_decoy_psm=, include_original_psm=)` reading a path directly (dropped the non-existent `parse_psm_list` / `keep_original` / `generate_modified_decoys`).
- README config examples switched from `.toml` to valid `.json` (the loader is JSON-only).

## Misc

- Modernized `with`-statement patching in `tests/test_file_handler.py` (parenthesized context managers).
- Added `uv.lock` to `.gitignore`.

## Testing

Full suite: **34 passed** (previously 32 passed / 2 failed on the `applymap` breakage).
