### PR TITLE
docs: mark project as beta software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Mumble
 
 **Finding the perfect unimod match for your mass shifted PSM**
+
+> [!IMPORTANT]
+> Mumble is under active development and should be considered **beta** software. It is usable
+> and already improves identification rates on open-modification-search-style data, but
+> occasional errors can still occur, especially on unusual input files or uncommon
+> modifications. Results should be reviewed before downstream use, and issues can be reported on
+> the [issue tracker](https://github.com/compomics/mumble/issues).
+
 ## Overview
 
 The PSM Modification Handler is a Python-based tool designed to find candidate unimod modifications for mass shifts. The tool allows users to apply modifications to PSMs, localize mass shifts, and generate lists of modified PSMs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ keywords = [
 authors = [{ name = "Arthur Declercq", email = "Arthur.Declercq@hotmail.com" }]
 license = { file = "LICENSE" }
 classifiers = [
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Mumble is functional but still under active development; occasional errors are expected. Add a visible beta notice to the README and a matching Development Status classifier so this is clear to new users.